### PR TITLE
Update wifi-helper-spec.coffee

### DIFF
--- a/spec/utils/wifi-helper-spec.coffee
+++ b/spec/utils/wifi-helper-spec.coffee
@@ -1,4 +1,5 @@
 whenjs = require 'when'
+fs = require 'fs-plus'
 
 describe 'getting current SSID when', ->
 	WifiHelper = null


### PR DESCRIPTION
Updated wifi-helper-spec.coffee by adding `fs = require 'fs-extra'`. This fixed the Travis CI build error
` ReferenceError: fs is not defined (utils/wifi-helper-spec.coffee:###:12)` so that this pull request passes with no errors.